### PR TITLE
Allow multiple clusters per VPC

### DIFF
--- a/client_secgroup.tf
+++ b/client_secgroup.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "client" {
-    name        = "Couchbase Client"
+    name_prefix = "CouchbaseClient"
     description = "Allows Couchbase protocols from clients to nodes in the cluster"
     vpc_id      = "${data.aws_subnet.first.vpc_id}"
 }

--- a/internode_secgroup.tf
+++ b/internode_secgroup.tf
@@ -3,7 +3,7 @@ data "aws_subnet" "first" {
 }
 
 resource "aws_security_group" "internode" {
-    name        = "Couchbase Inter-Node"
+    name_prefix = "CouchbaseInterNode"
     description = "Allows Couchbase protocols between nodes in the cluster"
     vpc_id      = "${data.aws_subnet.first.vpc_id}"
 }


### PR DESCRIPTION
Updated security group to use name_prefix instead of name to allow deployment of multiple clusters